### PR TITLE
Capture Ctrl-C key during the execution

### DIFF
--- a/rosa-burner.py
+++ b/rosa-burner.py
@@ -5,6 +5,7 @@ import sys
 import time
 import importlib
 import threading
+import signal
 from libs.arguments import Arguments
 from libs.logging import Logging
 from libs.elasticsearch import Elasticsearch
@@ -44,6 +45,9 @@ if __name__ == "__main__":
         utils.verify_cmnd(command)
 
     platform.initialize()
+
+    logging.info("Starting capturing Ctrl-C key from this point")
+    signal.signal(signal.SIGINT, utils.set_force_terminate)
 
     watcher = threading.Thread(target=platform.watcher)
     watcher.daemon = True


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Capture Ctrl-C so wrapper wont be killed and will stop installing clusters, letting running install to finish and delete everything before exiting

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
