### PR TITLE
setting the index timestamp

### DIFF
--- a/libs/platforms/rosa/hypershift/hypershift.py
+++ b/libs/platforms/rosa/hypershift/hypershift.py
@@ -494,6 +494,7 @@ class Hypershift(Rosa):
         else:
             cluster_info['status'] = "installed"
             cluster_end_time = int(datetime.datetime.utcnow().timestamp())
+            index_time = datetime.datetime.utcnow().isoformat()
             # Getting againg metadata to update the cluster status
             cluster_info["metadata"] = self.get_metadata(cluster_name)
             cluster_info["install_duration"] = cluster_end_time - cluster_start_time
@@ -544,7 +545,7 @@ class Hypershift(Rosa):
                 self.logging.error(err)
                 self.logging.error(f"Failed to write metadata_install.json file located at {cluster_info['path']}")
             if self.es is not None:
-                cluster_info["timestamp"] = datetime.datetime.utcnow().isoformat()
+                cluster_info["timestamp"] = index_time
                 self.es.index_metadata(cluster_info)
                 self.logging.info("Indexing Management cluster stats")
                 os.environ["START_TIME"] = f"{cluster_start_time_on_mc}"  # excludes pre-flight durations

--- a/libs/platforms/rosa/terraform/terraform.py
+++ b/libs/platforms/rosa/terraform/terraform.py
@@ -169,6 +169,7 @@ class Terraform(Rosa):
                         return 1
                 else:
                     cluster_end_time = int(datetime.datetime.utcnow().timestamp())
+                    index_time = datetime.datetime.utcnow().isoformat()
                     break
 
         cluster_info['status'] = "installed"
@@ -202,7 +203,7 @@ class Terraform(Rosa):
             self.logging.error(err)
             self.logging.error(f"Failed to write metadata_install.json file located at {cluster_info['path']}")
         if self.es is not None:
-            cluster_info["timestamp"] = datetime.datetime.utcnow().isoformat()
+            cluster_info["timestamp"] = index_time
             self.es.index_metadata(cluster_info)
 
     def _wait_for_workers(self, kubeconfig, worker_nodes, wait_time, cluster_name, machinepool_name):


### PR DESCRIPTION
to timestamp the graph when the control planes are ready this way we can observe any delays between cluster creations that represents the scheduling delays as well

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Pin the graph when the control planes are ready, this way we can observe any delays between cluster creations especially the MC scheduling delays.
Currently it timestamps after worker ready.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
