### PR TITLE
dump log file when there is any error executing a subcommand

### DIFF
--- a/libs/utils.py
+++ b/libs/utils.py
@@ -79,6 +79,7 @@ class Utils:
                 self.logging.error(f"Failed to execute command: {command}")
                 self.logging.error(stdout if stdout else "")
                 self.logging.error(stderr if stderr else "")
+                self.logging.error(log_file if output_file else "")
             return process.returncode, stdout, stderr
         except Exception as err:
             self.logging.error(f"Error executing command: {command}")


### PR DESCRIPTION
When executing the cluster_create command, as we are using a log file to dump the output, on execution failures we are loosing the output, this commit will dump the content of the log file to avoid errors like this:

2023-11-23 10:57:54,709 ERROR utils - subprocess_exec: Failed to execute command: rosa create cluster --cluster-name rbur-ls8-0001 --replicas 3 --hosted-cp --sts --mode auto -y --output json --oidc-config-id xxxx --properties provision_shard_id:xxxx
2023-11-23 10:57:54,710 ERROR utils - subprocess_exec: 
2023-11-23 10:57:54,710 ERROR utils - subprocess_exec: 
2023-11-23 10:57:54,710 DEBUG hypershift - create_cluster: None
2023-11-23 10:57:54,710 DEBUG hypershift - create_cluster: None


- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
