### PR TITLE
Add --region parameter to rosa create command, without it, it cannot find the vpc subnets

### DIFF
--- a/libs/platforms/rosa/hypershift/hypershift.py
+++ b/libs/platforms/rosa/hypershift/hypershift.py
@@ -419,7 +419,7 @@ class Hypershift(Rosa):
         os.mkdir(cluster_info["path"])
         self.logging.debug("Attempting cluster installation")
         self.logging.debug("Output directory set to %s" % cluster_info["path"])
-        cluster_cmd = ["rosa", "create", "cluster", "--cluster-name", cluster_name, "--replicas", str(cluster_info["workers"]), "--hosted-cp", "--sts", "--mode", "auto", "-y", "--output", "json", "--oidc-config-id", platform.environment["oidc_config_id"]]
+        cluster_cmd = ["rosa", "create", "cluster", "--cluster-name", cluster_name, "--replicas", str(cluster_info["workers"]), "--hosted-cp", "--sts", "--mode", "auto", "-y", "--output", "json", "--oidc-config-id", platform.environment["oidc_config_id"], "--region", platform.environment["aws"]["region"]]
         if platform.environment["create_vpcs"]:
             self.logging.debug(platform.environment["vpcs"][(cluster_info["index"] - 1) % len(platform.environment["vpcs"])])
             cluster_info["vpc"] = platform.environment["vpcs"][(cluster_info["index"] - 1) % len(platform.environment["vpcs"])]


### PR DESCRIPTION
Automation is failing on the create command because VPC subnets are not being detected:

E: Failed to get the list of subnets: InvalidSubnetID.NotFound: The subnet ID 'subnet-007d1ec0d50c4b125' does not exist
	status code: 400, request id: 908c1f08-e20d-4b92-aaf5-af657c0db2b1


Adding --region AWS_REGION seems to fix the problem, it is like a requirement on the last rosa cli version

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
