### PR TITLE
Adapt CI to new name of the wrapper

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,15 +3,15 @@ name: Execute tests
 on:
   workflow_call:
     secrets:
-      ROSA_BURNER_OCM_TOKEN:
+      HCP_BURNER_OCM_TOKEN:
         required: true
       AWS_ACCESS_KEY:
         required: true
       AWS_SECRET_KEY:
         required: true
-      ROSA_BURNER_HYPERSHIFT_SERVICE_CLUSTER:
+      HCP_BURNER_HYPERSHIFT_SERVICE_CLUSTER:
         required: true
-      ROSA_BURNER_ES_URL:
+      HCP_BURNER_ES_URL:
         required: true
 jobs:
   test-rosa:
@@ -46,13 +46,13 @@ jobs:
       run: find . -name 'requirements.txt' -exec pip install -r {} \;
 
     - name: Execute tests
-      run: python rosa-burner.py --config-file ./rosa-burner.ini --platform rosa --subplatform ${{matrix.subplatform}}
+      run: python hcp-burner.py --config-file ./hcp-burner.ini --platform rosa --subplatform ${{matrix.subplatform}}
       env:
-        ROSA_BURNER_OCM_TOKEN: ${{ secrets.ROSA_BURNER_OCM_TOKEN }}
-        ROSA_BURNER_AWS_ACCOUNT_FILE: "/tmp/aws_config.ini"
-        ROSA_BURNER_HYPERSHIFT_SERVICE_CLUSTER: ${{ secrets.ROSA_BURNER_HYPERSHIFT_SERVICE_CLUSTER}}
-        ROSA_BURNER_ES_URL: ${{ secrets.ROSA_BURNER_ES_URL}}
-        ROSA_BURNER_ES_INDEX: "rosa-burner"
+        HCP_BURNER_OCM_TOKEN: ${{ secrets.HCP_BURNER_OCM_TOKEN }}
+        HCP_BURNER_AWS_ACCOUNT_FILE: "/tmp/aws_config.ini"
+        HCP_BURNER_HYPERSHIFT_SERVICE_CLUSTER: ${{ secrets.HCP_BURNER_HYPERSHIFT_SERVICE_CLUSTER}}
+        HCP_BURNER_ES_URL: ${{ secrets.HCP_BURNER_ES_URL}}
+        HCP_BURNER_ES_INDEX: "rosa-burner"
 
     # - name: Install bats
     #   uses: mig4/setup-bats@v1


### PR DESCRIPTION
We need to first update the CI so [PR](https://github.com/cloud-bulldozer/rosa-burner/pull/24) for renaming will use it 

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
